### PR TITLE
增加PDF采样率配置 pdf转图片dpi为72*scale

### DIFF
--- a/src/bisheng_unstructured/api/pipeline.py
+++ b/src/bisheng_unstructured/api/pipeline.py
@@ -23,8 +23,8 @@ from .any2pdf import Any2PdfCreator
 from .types import UnstructuredInput, UnstructuredOutput
 
 
-def partition_pdf(filename, model_params, **kwargs):
-    doc = PDFDocument(file=filename, model_params=model_params, **kwargs)
+def partition_pdf(filename, model_params,scale, **kwargs):
+    doc = PDFDocument(file=filename, model_params=model_params,scale=scale, **kwargs)
     _ = doc.pages
     return doc.elements
 
@@ -105,7 +105,7 @@ class Pipeline(object):
         part_inp = {"filename": filename, **inp.parameters}
         part_func = PARTITION_MAP.get(file_type)
         if part_func == partition_pdf or part_func == partition_image:
-            part_inp.update({"model_params": self.pdf_model_params})
+            part_inp.update({"model_params": self.pdf_model_params,"scale":inp.scale})
         try:
             elements = part_func(**part_inp)
             mode = inp.mode

--- a/src/bisheng_unstructured/api/types.py
+++ b/src/bisheng_unstructured/api/types.py
@@ -11,6 +11,7 @@ class UnstructuredInput(BaseModel):
     mode: str = "text"  # text, partition, vis, topdf
     file_path: Optional[str] = None
     file_type: Optional[str] = None
+    scale: Optional[int] = 1
 
 
 class UnstructuredOutput(BaseModel):


### PR DESCRIPTION
模糊的pdf经过bisheng-unstructured处理，OCR出来的字会有错误，提高转换pdf成图片的dpi，提升模糊PDF识别的准确率