### PR TITLE
fix：修复rt_server缺失时，前端无法预览文件

### DIFF
--- a/src/bisheng_unstructured/api/main.py
+++ b/src/bisheng_unstructured/api/main.py
@@ -99,13 +99,9 @@ async def etl4_llm(inp: UnstructuredInput):
 
         inp.file_path = file_path
         inp.file_type = file_type
-        if pipeline.mode == "local" and inp.mode == "partition":
-            # 本地模式只支持text 有限格式
-            logger.info(f"local_pipeline mode=[{inp.mode}] filename=[{inp.filename}]")
-            inp.mode = "text"
 
-        if inp.file_type != "pdf" and inp.mode == "partition":
-            # partition 模式，转pdf 后处理
+        if inp.file_type != "pdf" and (inp.mode == "partition" or inp.mode == "local_partition"):
+            # partition 和 local_partition 模式，转pdf 后处理
             inp.mode = "topdf"
             pdf_ret = pipeline.predict(inp)
             if pdf_ret and pdf_ret.status_code != 200:
@@ -116,9 +112,14 @@ async def etl4_llm(inp: UnstructuredInput):
             inp.file_type = "pdf"
             inp.mode = "partition"
 
+        if pipeline.mode == "local" and inp.mode == "partition":
+            # 本地模式只支持text 有限格式
+            logger.info(f"local_pipeline mode=local_partition filename=[{inp.filename}]")
+            inp.mode = "local_partition"
+
         timer.toc()
         outp = pipeline.predict(inp)
-        if inp.mode == "partition" and outp.status_code == 200:
+        if (inp.mode == "partition" or inp.mode == "local_partition") and outp.status_code == 200:
             with open(file_path, "rb") as fin:
                 outp.b64_pdf = base64.b64encode(fin.read()).decode("utf-8")
 

--- a/src/bisheng_unstructured/api/pipeline.py
+++ b/src/bisheng_unstructured/api/pipeline.py
@@ -169,6 +169,9 @@ class Pipeline(object):
             elif mode == "vis":
                 html_text = visualize_html(elements)
                 result = UnstructuredOutput(html_text=html_text)
+            elif mode == "local_partition":
+                text = save_to_txt(elements)
+                result = UnstructuredOutput(text=text)
 
             return result
         except Exception as e:


### PR DESCRIPTION
原代码在local_pipeline的partition模式下，模式被改为了text，但是这种情况下，不会有pdf数据返回，进而导致前端无法展示页面。

我增加了local_partition模式，复用了原partition模式下先转pdf的逻辑。

我自己测试了pdf、docx、pptx、xlsx文件，均可正常预览